### PR TITLE
KeyguardIndication: Fix glitchy charging info on AOD

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
@@ -915,7 +915,7 @@ public class KeyguardIndicationController {
             if (!TextUtils.equals(mTopIndicationView.getText(), newIndication)) {
                 mWakeLock.setAcquired(true);
                 mTopIndicationView.switchIndication(newIndication, null,
-                        true, () -> mWakeLock.setAcquired(false));
+                        animate, () -> mWakeLock.setAcquired(false));
             }
             return;
         }


### PR DESCRIPTION
* This is second fix following https://github.com/crdroidandroid/android_frameworks_base/commit/b0c0883b4fc9bd06e6d13aca427cfbf4f13e5f38
* Seems to be AOSP bug. :)

Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>